### PR TITLE
Handle dpkg dependency issues during package install

### DIFF
--- a/debian9-x86_64.sh
+++ b/debian9-x86_64.sh
@@ -204,6 +204,13 @@ install_omr_package() {
         done
         if ! dpkg $dpkg_opts -i "$dest"; then
             rc=$?
+            if apt-get -y -f install; then
+                if dpkg $dpkg_opts -i "$dest"; then
+                    rc=0
+                else
+                    rc=$?
+                fi
+            fi
         else
             rc=0
         fi


### PR DESCRIPTION
## Summary
- retry dpkg installs after running apt-get -f install to resolve missing dependencies when using install_omr_package

## Testing
- sh -n debian9-x86_64.sh

------
https://chatgpt.com/codex/tasks/task_e_68d54422bbc48327b4eb4ac156f414c4