### PR TITLE
Handle apt-get check failure under set -e

### DIFF
--- a/debian9-x86_64.sh
+++ b/debian9-x86_64.sh
@@ -379,10 +379,15 @@ fi
 #	exit 1
 #fi
 echo "Check about broken packages..."
-apt-get check >/dev/null 2>&1
-if [ "$?" -ne 0 ]; then
-	echo "E: \`apt-get check\` failed, you may have broken packages. Aborting..."
-	exit 1
+set +e
+apt_get_check_status=0
+if ! apt-get check >/dev/null 2>&1; then
+        apt_get_check_status=$?
+fi
+set -e
+if [ "$apt_get_check_status" -ne 0 ]; then
+        echo "E: \`apt-get check\` failed, you may have broken packages. Aborting..."
+        exit 1
 fi
 
 # Fix old string...


### PR DESCRIPTION
## Summary
- prevent the installer script from exiting silently when `apt-get check` fails under `set -e`
- capture the `apt-get check` exit code with `set +e` and re-enable `set -e` afterwards
- surface the existing error message when broken packages are detected

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5480c328c8327b89b8489aebdd998