### PR TITLE
Remove upstream kernel options from Debian 9 installer

### DIFF
--- a/debian9-x86_64.sh
+++ b/debian9-x86_64.sh
@@ -6,7 +6,6 @@
 # See /LICENSE for more information.
 #
 
-UPSTREAM=${UPSTREAM:-no}
 SHADOWSOCKS_PASS=${SHADOWSOCKS_PASS:-$(head -c 32 /dev/urandom | base64 -w0)}
 GLORYTUN_PASS=${GLORYTUN_PASS:-$(od -vN "32" -An -tx1 /dev/urandom | tr '[:lower:]' '[:upper:]' | tr -d " \n")}
 DSVPN_PASS=${DSVPN_PASS:-$(od -vN "32" -An -tx1 /dev/urandom | tr '[:lower:]' '[:upper:]' | tr -d " \n")}
@@ -30,9 +29,6 @@ OPENVPN=${OPENVPN:-yes}
 DSVPN=${DSVPN:-yes}
 WIREGUARD=${WIREGUARD:-yes}
 SOURCES=${SOURCES:-no}
-if [ "$UPSTREAM" = "yes" ]; then
-	SOURCES="yes"
-fi
 NOINTERNET=${NOINTERNET:-no}
 REINSTALL=${REINSTALL:-yes}
 SPEEDTEST=${SPEEDTEST:-yes}
@@ -41,11 +37,6 @@ INTERFACE=${INTERFACE:-$(ip -o -4 route show to default | grep -m 1 -Po '(?<=dev
 KERNEL_VERSION="5.4.207"
 KERNEL_PACKAGE_VERSION="1.22"
 KERNEL_RELEASE="${KERNEL_VERSION}-mptcp_${KERNEL_PACKAGE_VERSION}"
-if [ "$UPSTREAM" = "yes" ]; then
-	KERNEL_VERSION="5.15.57"
-	KERNEL_PACKAGE_VERSION="1.6"
-	KERNEL_RELEASE="${KERNEL_VERSION}-mptcp_${KERNEL_VERSION}-${KERNEL_PACKAGE_VERSION}"
-fi
 GLORYTUN_UDP_VERSION="32267e86a6da05b285bb3bf2b136c105dc0af4bb"
 GLORYTUN_UDP_BINARY_VERSION="0.3.4-5"
 GLORYTUN_TCP_BINARY_VERSION="0.0.35-3"
@@ -63,9 +54,6 @@ V2RAY_VERSION="4.43.0"
 V2RAY_PLUGIN_VERSION="4.43.0"
 EASYRSA_VERSION="3.0.6"
 SHADOWSOCKS_VERSION="7407b214f335f0e2068a8622ef3674d868218e17"
-if [ "$UPSTREAM" = "yes" ]; then
-	SHADOWSOCKS_VERSION="410950d87d8cdf8502d8f59a79dc0ff4c7677543"
-fi
 IPROUTE2_VERSION="29da83f89f6e1fe528c59131a01f5d43bcd0a000"
 SHADOWSOCKS_BINARY_VERSION="3.3.5-3"
 DEFAULT_USER="openmptcprouter"
@@ -311,32 +299,6 @@ apt-get -y -o Dpkg::Options::="--force-overwrite" install tracebox
 echo "Install iperf3 OpenMPTCProuter edition"
 apt-get -y -o Dpkg::Options::="--force-overwrite" install omr-iperf3
 
-if [ "$UPSTREAM" = "yes" ]; then
-	echo "Compile and install mptcpize..."
-	apt-get -y install --no-install-recommends build-essential
-	cd /tmp
-	git clone https://github.com/Ysurac/mptcpize.git
-	cd mptcpize
-	make
-	make install
-	cd /tmp
-	rm -rf /tmp/mptcpize
-	echo "Compile and install iproute2..."
-	apt-get -y install --no-install-recommends bison libbison-dev flex
-	#wget https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.16.0.tar.gz
-	#tar xzf iproute2-5.16.0.tar.gz
-	#cd iproute2-5.16.0
-	git clone git://git.kernel.org/pub/scm/network/iproute2/iproute2.git 
-	cd iproute2
-	git checkout 29da83f89f6e1fe528c59131a01f5d43bcd0a000
-	make
-	make install
-	cd /tmp
-	rm -rf iproute2
-	echo "MPTCPize iperf3..."
-	mptcpize enable iperf3
-fi
-
 apt-get -y remove shadowsocks-libev
 
 if [ "$SOURCES" = "yes" ]; then
@@ -534,11 +496,7 @@ if [ "$OMR_ADMIN" = "yes" ]; then
 	[ "$(ip -6 a)" != "" ] && {
 		systemctl enable omr-admin-ipv6.service
 	}
-	systemctl enable omr-admin.service
-	if [ "$UPSTREAM" = "yes" ]; then
-		mptcpize enable omr-admin.service
-		[ "$(ip -6 a)" != "" ] && mptcpize enable omr-admin-ipv6.service
-	fi
+        systemctl enable omr-admin.service
 fi
 
 # Get shadowsocks optimization
@@ -702,9 +660,6 @@ if [ "$V2RAY" = "yes" ]; then
 	fi
 	systemctl daemon-reload
 	systemctl enable v2ray.service
-	if [ "$UPSTREAM" = "yes" ]; then
-		mptcpize enable v2ray
-	fi
 fi
 
 if systemctl -q is-active mlvpn@mlvpn0.service; then
@@ -948,11 +903,8 @@ if [ "$OPENVPN" = "yes" ]; then
 	fi
 	mkdir -p /etc/openvpn/ccd
 	systemctl enable openvpn@tun0.service
-	systemctl enable openvpn@tun1.service
-	if [ "$UPSTREAM" = "yes" ]; then
-		mptcpize enable openvpn@tun0
-	fi
-	systemctl enable openvpn@bonding1.service
+        systemctl enable openvpn@tun1.service
+        systemctl enable openvpn@bonding1.service
 	systemctl enable openvpn@bonding2.service
 	systemctl enable openvpn@bonding3.service
 	systemctl enable openvpn@bonding4.service
@@ -1065,9 +1017,6 @@ if [ "$DSVPN" = "yes" ]; then
 		apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-overwrite" install omr-dsvpn=${DSVPN_BINARY_VERSION}
 		DSVPN_PASS=$(cat /etc/dsvpn/dsvpn0.key | tr -d "\n")
 	fi
-	if [ "$UPSTREAM" = "yes" ]; then
-		mptcpize enable dsvpn-server@dsvpn0
-	fi
 fi
 
 # Install Glorytun TCP
@@ -1081,16 +1030,9 @@ if [ "$SOURCES" = "yes" ]; then
 	rm -f /usr/bin/glorytun-tcp
 	apt-get -y install build-essential pkg-config autoconf automake
 	rm -rf /tmp/glorytun-0.0.35
-	cd /tmp
-	if [ "$UPSTREAM" = "yes" ]; then
-		wget -O /tmp/glorytun-0.0.35.tar.gz https://github.com/Ysurac/glorytun/archive/refs/heads/tcp.tar.gz
-	else
-		wget -O /tmp/glorytun-0.0.35.tar.gz http://github.com/angt/glorytun/releases/download/v0.0.35/glorytun-0.0.35.tar.gz
-	fi
-	tar xzf glorytun-0.0.35.tar.gz
-	if [ "$UPSTREAM" = "yes" ]; then
-		mv /tmp/glorytun-tcp /tmp/glorytun-0.0.35
-	fi
+        cd /tmp
+        wget -O /tmp/glorytun-0.0.35.tar.gz http://github.com/angt/glorytun/releases/download/v0.0.35/glorytun-0.0.35.tar.gz
+        tar xzf glorytun-0.0.35.tar.gz
 	cd glorytun-0.0.35
 	./autogen.sh
 	./configure


### PR DESCRIPTION
## Summary
- remove the UPSTREAM flag and associated kernel overrides from the Debian 9 VPS installer script
- drop upstream-only mptcpize/iproute2 builds and service wrapping logic
- simplify Glorytun TCP source retrieval now that upstream mode is no longer supported

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d56bd29f108327b2ae24068d2a17c0