### PR TITLE
Add fallback download for omr-vps-admin package

### DIFF
--- a/debian9-x86_64.sh
+++ b/debian9-x86_64.sh
@@ -473,7 +473,15 @@ if [ "$OMR_ADMIN" = "yes" ]; then
 			OMR_ADMIN_PASS_ADMIN2=$(cat /etc/openmptcprouter-vps-admin/omr-admin-config.json | jq -r .users[0].admin.user_password | tr -d "\n")
 			[ -n "$OMR_ADMIN_PASS_ADMIN2" ] && [ "$OMR_ADMIN_PASS_ADMIN2" != "AdminMySecretKey" ] && OMR_ADMIN_PASS_ADMIN=$OMR_ADMIN_PASS_ADMIN2
 		fi
-		apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-overwrite" -y install omr-vps-admin=${OMR_ADMIN_BINARY_VERSION}
+                if ! apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-overwrite" -y install omr-vps-admin=${OMR_ADMIN_BINARY_VERSION}; then
+                        OMR_ADMIN_DEB="/tmp/omr-vps-admin_${OMR_ADMIN_BINARY_VERSION}_all.deb"
+                        wget -O "${OMR_ADMIN_DEB}" "https://github.com/Brazzo978/openmptcprouter-vps/raw/refs/heads/omr-vps-0.1028-def/Pack/omr-vps-admin_${OMR_ADMIN_BINARY_VERSION}_all.deb"
+                        apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-overwrite" -y install "${OMR_ADMIN_DEB}" || {
+                                dpkg -i "${OMR_ADMIN_DEB}"
+                                apt-get -f -y install
+                        }
+                        rm -f "${OMR_ADMIN_DEB}"
+                fi
 		if [ ! -f /etc/openmptcprouter-vps-admin/omr-admin-config.json ]; then
 			cp /usr/share/omr-admin/omr-admin-config.json /etc/openmptcprouter-vps-admin/
 		fi


### PR DESCRIPTION
## Summary
- download and install the omr-vps-admin .deb from GitHub when the requested version is missing from apt repositories

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d58511fbac832781f14e2fd3397619